### PR TITLE
Disable random odo integration tests for a PR change

### DIFF
--- a/scripts/openshiftci-presubmit-devfiles-odo-all-tests.sh
+++ b/scripts/openshiftci-presubmit-devfiles-odo-all-tests.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# fail if some commands fails
+set -e
+# show commands
+set -x
+
+git clone https://github.com/openshift/odo $GOPATH/src/github.com/openshift/odo
+cp scripts/openshiftci-presubmit-devfiles-odo-all-tests.sh $GOPATH/src/github.com/openshift/odo/scripts/
+sed -i 's/-randomizeAllSpecs//g' $GOPATH/src/github.com/openshift/odo/Makefile
+
+$GOPATH/src/github.com/openshift/odo/scripts/openshiftci-presubmit-devfiles-odo-all-tests.sh
+
+cd $GOPATH/src/github.com/openshift/odo
+
+export CI="openshift"
+make configure-installer-tests-cluster
+make bin
+mkdir -p $GOPATH/bin
+make goget-ginkgo
+export PATH="$PATH:$(pwd):$GOPATH/bin"
+export CUSTOM_HOMEDIR=$ARTIFACT_DIR
+
+# Copy kubeconfig to temporary kubeconfig file
+# Read and Write permission to temporary kubeconfig file
+TMP_DIR=$(mktemp -d)
+cp $KUBECONFIG $TMP_DIR/kubeconfig
+chmod 640 $TMP_DIR/kubeconfig
+export KUBECONFIG=$TMP_DIR/kubeconfig
+
+# Login as developer
+oc login -u developer -p password@123
+
+# Check login user name for debugging purpose
+oc whoami
+
+make test-integration-devfile
+
+cp -r $GOPATH/src/github.com/openshift/odo/tests/integration/reports $ARTIFACT_DIR
+
+oc logout


### PR DESCRIPTION
### What does this PR do?
Current Odo integration tests are configured to run random test specs periodically to save time/resources. Running random specs in a periodic test run is acceptable, however, for performance measurement it would be harder to get a test result matrix thus it's preferable to run all the tests for PR change. 

### What issues does this PR fix or reference?
https://github.com/devfile/api/issues/417

### Is your PR tested? 
This PR should be merged first in order to test out Openshift CI test associated with this change. 