### PR TITLE
Change license to Apache 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -187,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Red Hat, Inc.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
### What does this PR do?

We are about to propose Devfile as a CNCF sandbox project. Most of the CNCF projects are licensed under Apache-2.0 and that’s what the community is used to. Re-licensing to Apache-2.0 would make the process smoother and augment our chances to successfully transition the project to CNCF sandbox. Both EPL-2.0 and Apache-2.0 are open source licenses that are widely used in the industry and Apache-2.0 is considered more permissive than EPL-2.0.

⚠️ This PR is in draft mode. We are contacting existing contributors to get their approval and then we will merge it.

### What issues does this PR fix or reference?

https://github.com/devfile/api/issues/426
