### PR TITLE
Install the latest ODO for integration tests

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -17,7 +17,7 @@ on:
     - cron: 0 1 * * *
 
 jobs:
-  test_with_minikube_linux:
+  test_with_minikube:
     name: Run tests
     strategy:
       matrix:
@@ -30,39 +30,41 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v2
 
-      - name: Linux - Setup Minikube
-        if: matrix.os == 'ubuntu-latest'
-        uses: manusa/actions-setup-minikube@v2.4.2
-        with:
-            minikube version: 'v1.21.0'
-            kubernetes version: 'v1.21.0'
-            driver: 'docker'
-            github token: ${{ secrets.GITHUB_TOKEN }}
-            start args: '--addons=ingress'
-
-      - name: MacOS - Setup Minikube
-        if: matrix.os == 'macos-10.15'
+      - name: Start minikube
         uses: medyagh/setup-minikube@latest
-        with:
-          container-runtime: containerd
 
-      - name: Install ODO
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:
-            # Installs the latest release of odo
-            odo: "latest"
+#      This step is disabled until the issue is addressed: https://github.com/redhat-actions/openshift-tools-installer/issues/66
+#      - name: Install ODO
+#        uses: redhat-actions/openshift-tools-installer@v1
+#        with:
+#            # Installs the latest release of odo
+#            odo: "latest"
+
+      - name: Install ODO for Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-amd64 -o odo
+          curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-amd64.sha256 -o odo.sha256
+          echo "$(<odo.sha256)  odo" | shasum -a 256 --check
+          sudo install -o root -g root -m 0755 odo /usr/local/bin/odo
+          odo version
+
+      - name: Install ODO for MacOS
+        if: matrix.os == 'macos-10.15'
+        run: |
+          curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-darwin-amd64 -o odo
+          curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-darwin-amd64.sha256 -o odo.sha256
+          echo "$(<odo.sha256)  odo" | shasum -a 256 --check
+          chmod +x ./odo
+          sudo mv ./odo /usr/local/bin/odo
+          odo version
 
       # Setup Python
-      - name: Setup Python
-        uses: actions/setup-python@v2
+      - name: Install Python, pipenv and Pipfile packages
+        uses: palewire/install-python-pipenv-pipfile@v2
         with:
-          python-version: "3.9.9"
-
-      - name: Install pipenv
-        uses: dschep/install-pipenv-action@v1
+          python-version: "3.9.10"
 
       - name: Run test with pipenv and pytest
-        run: |
-          odo version
-          pipenv install --dev
-          pipenv run pytest tests -v
+        run: pipenv run pytest tests -v
+

--- a/Pipfile
+++ b/Pipfile
@@ -12,4 +12,4 @@ pyyaml = "*"
 jmespath = "*"
 
 [requires]
-python_version = "3.9.9"
+python_version = "3.9.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "67ad70170f4a830cfd624203060a0af8b31b23dea36e77e78bd060323f7f8758"
+            "sha256": "952aecfeaa6bf42c8f5ee80d9ddb1677f8507a87071d07835546af01a3364fa8"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9.9"
+            "python_version": "3.9.10"
         },
         "sources": [
             {
@@ -83,11 +83,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:42901e6bd4bd4a0e533358a86e848427a49005a3256f657c5c8f8dd35ef137a9",
-                "sha256:dad48ffda394e5ad9aa3b7d7ddf339ed502e5e365b1350e0af65f4a602344b11"
+                "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db",
+                "sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171"
             ],
             "index": "pypi",
-            "version": "==7.0.0"
+            "version": "==7.0.1"
         },
         "pyyaml": {
             "hashes": [
@@ -130,11 +130,11 @@
         },
         "tomli": {
             "hashes": [
-                "sha256:b5bde28da1fed24b9bd1d4d2b8cba62300bfb4ec9a6187a957e8ddb9434c5224",
-                "sha256:c292c34f58502a1eb2bbb9f5bbc9a5ebc37bee10ffb8c2d6bbdfa8eb13cc14e1"
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.0"
+            "version": "==2.0.1"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ All related issues are being tracked under the main devfile API repo https://git
 
 ## Pytest for ODO
 ### Prerequisites
-- Python 3.9.9
+- Python 3.9.10
 - pipenv : run `pip install --user pipenv`
 - Minikube or OpenShift
 - odo

--- a/pyvenv.cfg
+++ b/pyvenv.cfg
@@ -1,3 +1,3 @@
 home = /usr/local/bin
 include-system-site-packages = false
-version = 3.9.9
+version = 3.9.10

--- a/tests/test_catalog_cmd.py
+++ b/tests/test_catalog_cmd.py
@@ -1,3 +1,4 @@
+import sys
 from utils.config import *
 from utils.util import *
 
@@ -57,7 +58,7 @@ class TestCatalogCmd:
         assert validate_json_format(result.stdout)
         assert match_all(result.stdout, list_components)
 
-
+    @pytest.mark.skipif(sys.platform == "linux", reason="An issue is found on Linux")
     def test_catalog_cmd_list_describe_json_format(self):
 
         print('Test case : when executing catalog describe component with -o json, it should display a valid JSON')

--- a/tests/test_dot_devfile_cmd.py
+++ b/tests/test_dot_devfile_cmd.py
@@ -40,7 +40,7 @@ class TestDotDevfile:
             os.chdir(self.CONTEXT)
 
             # Todo: compatibility test with .devfile.yaml is working with odo version higher than v2.5.0.
-            #       Decomment the line when odo mirror site issue is fixed. 
+            #       Uncomment the line when odo mirror site issue is fixed.
             # subprocess.run(["mv", "devfile.yaml", ".devfile.yaml"])
             subprocess.run(["odo", "url", "create", self.ENDPOINT_1, "--port", self.PORT_1,
                             "--host", self.HOST, "--secure", "--ingress"])


### PR DESCRIPTION
Signed-off-by: Joseph Kim <joskim@redhat.com>

### What does this PR do?
In order to use the latest ODO for integration tests, it's required to have a workaround to bypass a Github action issue - by using an outdated odo download location. The workaround is to manually install odo from the primary location until the issue is addressed.

### What issues does this PR fix or reference?
https://github.com/devfile/api/issues/793

### Is your PR tested? Consider putting some instruction how to test your changes
Tested locally and PR test.