### PR TITLE
Re-enable odo tests with the latest odo version

### DIFF
--- a/tests/test_create_cmd.py
+++ b/tests/test_create_cmd.py
@@ -136,14 +136,13 @@ class TestCreateCmd:
             copy_example_devfile(source_devfile_path, tmp_workspace)
             subprocess.run(["odo", "create", "nodejs", "--starter", "nodejs-starter"])
 
-            # Todo: this check is flacky in git actions
-            # list_files: list[str] = [
-            #     "package.json",
-            #     "package-lock.json",
-            #     "README.md",
-            #     "devfile.yaml"
-            # ]
-            # assert check_files_exist(tmp_workspace, list_files)
+            list_files: list[str] = [
+                "package.json",
+                "package-lock.json",
+                "README.md",
+                "devfile.yaml"
+            ]
+            assert check_files_exist(tmp_workspace, list_files)
 
 
     def test_create_component_with_devfile_flag(self):

--- a/tests/test_dot_devfile_cmd.py
+++ b/tests/test_dot_devfile_cmd.py
@@ -39,9 +39,7 @@ class TestDotDevfile:
 
             os.chdir(self.CONTEXT)
 
-            # Todo: compatibility test with .devfile.yaml is working with odo version higher than v2.5.0.
-            #       Uncomment the line when odo mirror site issue is fixed.
-            # subprocess.run(["mv", "devfile.yaml", ".devfile.yaml"])
+            subprocess.run(["mv", "devfile.yaml", ".devfile.yaml"])
             subprocess.run(["odo", "url", "create", self.ENDPOINT_1, "--port", self.PORT_1,
                             "--host", self.HOST, "--secure", "--ingress"])
 

--- a/tests/test_url_cmd.py
+++ b/tests/test_url_cmd.py
@@ -53,9 +53,9 @@ class TestUrlCmd:
                             "url {} already exist in devfile endpoint entry under container runtime".format(self.ENDPOINT))
 
             # should not allow to create URL with duplicate port
-            # result = subprocess.run(["odo", "url", "create", self.ENDPOINT_1, "--port", self.PORT_1,
-            #                          "--host", self.HOST, "--secure", "--ingress"],
-            #                         capture_output=True, text=True, check=False)
+            result = subprocess.run(["odo", "url", "create", self.ENDPOINT_1, "--port", self.PORT_1,
+                                     "--host", self.HOST, "--secure", "--ingress"],
+                                    capture_output=True, text=True, check=False)
 
             # Todo: it's not blocked by the odo used in the test. Need to verify if it's fixed in more recent release
             # assert contains(result.stdout, "port 3000 already exists in devfile endpoint entry")


### PR DESCRIPTION
### What does this PR do?
Re-enable some temporarily disabled odo tests after fixing a Github Actions related issue - by not using the latest odo version. The re-enabled tests should be now working with the latest odo. 

### What issues does this PR fix or reference?
https://github.com/devfile/api/issues/793

### Is your PR tested? Consider putting some instruction how to test your changes
Tested locally and by PR tests. 