### PR TITLE
Revert workaround as odo install issue is fixed

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -33,31 +33,11 @@ jobs:
       - name: Start minikube
         uses: medyagh/setup-minikube@latest
 
-#      This step is disabled until the issue is addressed: https://github.com/redhat-actions/openshift-tools-installer/issues/66
-#      - name: Install ODO
-#        uses: redhat-actions/openshift-tools-installer@v1
-#        with:
-#            # Installs the latest release of odo
-#            odo: "latest"
-
-      - name: Install ODO for Linux
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-amd64 -o odo
-          curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-amd64.sha256 -o odo.sha256
-          echo "$(<odo.sha256)  odo" | shasum -a 256 --check
-          sudo install -o root -g root -m 0755 odo /usr/local/bin/odo
-          odo version
-
-      - name: Install ODO for MacOS
-        if: matrix.os == 'macos-10.15'
-        run: |
-          curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-darwin-amd64 -o odo
-          curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-darwin-amd64.sha256 -o odo.sha256
-          echo "$(<odo.sha256)  odo" | shasum -a 256 --check
-          chmod +x ./odo
-          sudo mv ./odo /usr/local/bin/odo
-          odo version
+      - name: Install ODO
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+            # Installs the latest release of odo
+            odo: "latest"
 
       # Setup Python
       - name: Install Python, pipenv and Pipfile packages
@@ -66,5 +46,7 @@ jobs:
           python-version: "3.9.10"
 
       - name: Run test with pipenv and pytest
-        run: pipenv run pytest tests -v
+        run: |
+          odo version
+          pipenv run pytest tests -v
 


### PR DESCRIPTION
Signed-off-by: Joseph Kim <joskim@redhat.com>

### What does this PR do?
Revert the workaround to bypass the odo install issue as the issue is fixed. 


### What issues does this PR fix or reference?
https://github.com/devfile/api/issues/793

### Is your PR tested? Consider putting some instruction how to test your changes
Tested by PR tests
