### PR TITLE
Use kubectl inside minikube on MacOS

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -33,31 +33,11 @@ jobs:
       - name: Start minikube
         uses: medyagh/setup-minikube@latest
 
-#      This step is disabled until the issue is addressed: https://github.com/redhat-actions/openshift-tools-installer/issues/66
-#      - name: Install ODO
-#        uses: redhat-actions/openshift-tools-installer@v1
-#        with:
-#            # Installs the latest release of odo
-#            odo: "latest"
-
-      - name: Install ODO for Linux
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-amd64 -o odo
-          curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-linux-amd64.sha256 -o odo.sha256
-          echo "$(<odo.sha256)  odo" | shasum -a 256 --check
-          sudo install -o root -g root -m 0755 odo /usr/local/bin/odo
-          odo version
-
-      - name: Install ODO for MacOS
-        if: matrix.os == 'macos-10.15'
-        run: |
-          curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-darwin-amd64 -o odo
-          curl -L https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest/odo-darwin-amd64.sha256 -o odo.sha256
-          echo "$(<odo.sha256)  odo" | shasum -a 256 --check
-          chmod +x ./odo
-          sudo mv ./odo /usr/local/bin/odo
-          odo version
+      - name: Install ODO
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+            # Installs the latest release of odo
+            odo: "latest"
 
       # Setup Python
       - name: Install Python, pipenv and Pipfile packages
@@ -66,5 +46,7 @@ jobs:
           python-version: "3.9.10"
 
       - name: Run test with pipenv and pytest
-        run: pipenv run pytest tests -v
+        run: |
+          odo version
+          pipenv run pytest tests -v
 

--- a/tests/test_deploy_cmd.py
+++ b/tests/test_deploy_cmd.py
@@ -21,7 +21,6 @@ class TestDeployCmd:
         '''Runs at end of class'''
         subprocess.run(["odo", "project", "delete", cls.tmp_project_name, "-f", "-w"])
 
-    @pytest.mark.skipif(sys.platform == "darwin", reason="does not run on macOS at the moment")
     def test_deploy(self):
 
         print("Test case : should run odo deploy by using a devfile.yaml containing a deploy command")
@@ -45,7 +44,8 @@ class TestDeployCmd:
                             + os.path.abspath(self.CONTEXT))
             assert contains(result.stdout, "push quay.io/unknown-account/myimage")
 
-            result = subprocess.run(["kubectl", "get", "deployment", "my-component", "-n", "intg-test-project",
+            # use kubectl insdie minikube for MacOS
+            result = subprocess.run(["minikube", "kubectl", "--", "get", "deployment", "my-component", "-n", "intg-test-project",
                                      "-o", "jsonpath='{.spec.template.spec.containers[0].image}'"],
                                     capture_output=True, text=True, check=True)
             assert contains(result.stdout, "quay.io/unknown-account/myimage")


### PR DESCRIPTION
### What does this PR do?
On MacOS, minikube installed from the Github Actions is not installing a separate kubectl. As a workaround, test with kubectl calls should use the one inside minikube. 

### What issues does this PR fix or reference?
https://github.com/devfile/api/issues/795

### Is your PR tested? Consider putting some instruction how to test your changes
Tested locally and by PR test.