### PR TITLE
Add odo(v3.0) init tests with devfile

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
             # Installs the latest release of odo
-            odo: "latest"
+            odo: "2.5.0"
 
       # Setup Python
       - name: Install Python, pipenv and Pipfile packages

--- a/.github/workflows/pytest_odo.250.yaml
+++ b/.github/workflows/pytest_odo.250.yaml
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-name: Devfile integration tests (latest Odo release)
+name: Devfile integration tests (Odo v2.5.0 release)
 
 on:
   push:
@@ -36,7 +36,7 @@ jobs:
       - name: Install ODO
         uses: redhat-actions/openshift-tools-installer@v1
         with:
-            # Installs the latest release of odo
+            # Installs odo v2.5.0
             odo: "2.5.0"
 
       # Setup Python

--- a/tests/examples/source/devfiles/nodejs/devfile-with-subDir.yaml
+++ b/tests/examples/source/devfiles/nodejs/devfile-with-subDir.yaml
@@ -1,0 +1,46 @@
+apiVersion: 1.0.0
+metadata:
+  name: nodejs
+starterProjects:
+  - name: nodejs-starter
+    subDir: /app/
+    git:
+      remotes:
+        origin: "https://github.com/che-samples/web-nodejs-sample.git"
+components:
+  - type: dockerimage
+    image: registry.access.redhat.com/ubi8/nodejs-12:1-36
+    endpoints:
+      - name: "3000-tcp"
+        port: 3000
+    alias: runtime
+    env:
+      - name: FOO
+        value: "bar"
+    memoryLimit: 1024Mi
+    mountSources: true
+commands:
+  - name: build
+    actions:
+      - type: exec
+        component: runtime
+        command: npm install
+        workdir: ${PROJECTS_ROOT}
+  - name: devbuild
+    actions:
+      - type: exec
+        component: runtime
+        command: npm install
+        workdir: ${PROJECTS_ROOT}
+  - name: run
+    actions:
+      - type: exec
+        component: runtime
+        command: npm start
+        workdir: ${PROJECTS_ROOT}
+  - name: devrun
+    actions:
+      - type: exec
+        component: runtime
+        command: npm start
+        workdir: ${PROJECTS_ROOT}

--- a/tests/odo/test_create_cmd.py
+++ b/tests/odo/test_create_cmd.py
@@ -121,7 +121,7 @@ class TestCreateCmd:
                 "devfile.yaml"
             ]
 
-            assert check_files_exist(context, list_files)
+            assert check_files_exist(list_files, context)
 
 
     def test_create_component_with_starter_project_git_branch(self):
@@ -142,7 +142,7 @@ class TestCreateCmd:
                 "README.md",
                 "devfile.yaml"
             ]
-            assert check_files_exist(tmp_workspace, list_files)
+            assert check_files_exist(list_files, tmp_workspace)
 
 
     def test_create_component_with_devfile_flag(self):

--- a/tests/odo_300/test_init_cmd.py
+++ b/tests/odo_300/test_init_cmd.py
@@ -1,5 +1,6 @@
 import sys
 import tempfile
+import jmespath
 from utils.config import *
 from utils.util import *
 
@@ -7,6 +8,7 @@ from utils.util import *
 class TestInitCmd:
 
     CONTEXT = "test-context"
+    COMPONENT = "acomponent"
 
     tmp_project_name = None
 
@@ -26,36 +28,112 @@ class TestInitCmd:
 
         with tempfile.TemporaryDirectory() as tmp_workspace:
             os.chdir(tmp_workspace)
-            compName = "acomponent"
-            result = subprocess.run(["odo", "init", "--name", compName, "--devfile", "go"],
+            
+            result = subprocess.run(["odo", "init", "--name", self.COMPONENT, "--devfile", "go"],
                                     capture_output=True, text=True, check=True)
 
-            assert contains(result.stdout, "Your new component '{}' is ready in the current directory.".format(compName))
-            assert check_file_exist(tmp_workspace, "devfile.yaml")
+            assert contains(result.stdout, "Your new component '{}' is ready in the current directory.".format(self.COMPONENT))
+            assert check_file_exist("devfile.yaml", tmp_workspace)
 
             devfile_path = os.path.abspath(os.path.join(tmp_workspace, 'devfile.yaml'))
-            assert query_yaml(devfile_path, "metadata", "name", -1) == compName
+            assert query_yaml(devfile_path, "metadata", "name", -1) == self.COMPONENT
+
+
+    def test_init_with_devfile_flag_json_output(self):
+        print("Test case : should download a devfile.yaml file and correctly set the component name in it")
+
+        with tempfile.TemporaryDirectory() as tmp_workspace:
+            os.chdir(tmp_workspace)
+
+            result_json = subprocess.run(["odo", "init", "--name", self.COMPONENT, "--devfile", "go", "-o", "json"],
+                                    capture_output=True, text=True, check=True)
+
+            assert check_file_exist("devfile.yaml", tmp_workspace)
+            assert validate_json_format(result_json.stdout)
+
+            dict = json.loads(result_json.stdout)
+
+            assert contains(jmespath.search('devfilePath', dict), os.path.abspath(os.path.join(tmp_workspace, 'devfile.yaml')))
+            assert contains(jmespath.search('devfileData.devfile.schemaVersion', dict), "2.0.0")
+            assert jmespath.search('devfileData.supportedOdoFeatures.dev', dict)
+            assert not jmespath.search('devfileData.supportedOdoFeatures.debug', dict)
+            assert not jmespath.search('devfileData.supportedOdoFeatures.deploy', dict)
+            assert contains(jmespath.search('managedBy', dict), "odo")
+
+
+    def test_init_with_devfile_path(self):
+        print("Test case : using --devfile-path flag with a local devfile")
+
+        with tempfile.TemporaryDirectory() as tmp_workspace:
+            os.chdir(tmp_workspace)
+
+            source_devfile_path = get_source_devfile_path('nodejs/devfile-registry.yaml')
+
+            result = subprocess.run(["odo", "init", "--name", self.COMPONENT, "--devfile-path", source_devfile_path],
+                                    capture_output=True, text=True, check=True)
+
+            assert check_file_exist("devfile.yaml", tmp_workspace)
+            assert contains(result.stdout,
+                            "Your new component '{}' is ready in the current directory.".format(self.COMPONENT))
+
+            devfile_path = os.path.abspath(os.path.join(tmp_workspace, 'devfile.yaml'))
+            assert query_yaml(devfile_path, "metadata", "name", -1) == self.COMPONENT
+
+
+    def test_init_with_devfile_path_url(self):
+        print("Test case : using --devfile-path flag with a URL")
+
+        with tempfile.TemporaryDirectory() as tmp_workspace:
+            os.chdir(tmp_workspace)
+
+            source_devfile_path = "https://raw.githubusercontent.com/devfile/integration-tests/main/tests/examples/source/devfiles/nodejs/devfile.yaml"
+
+            result = subprocess.run(["odo", "init", "--name", self.COMPONENT, "--devfile-path", source_devfile_path],
+                                    capture_output=True, text=True, check=True)
+
+            assert check_file_exist("devfile.yaml", tmp_workspace)
+            assert contains(result.stdout,
+                            "Your new component '{}' is ready in the current directory.".format(self.COMPONENT))
+
+            devfile_path = os.path.abspath(os.path.join(tmp_workspace, 'devfile.yaml'))
+            assert query_yaml(devfile_path, "metadata", "name", -1) == self.COMPONENT
+
+
+    def test_init_with_devfile_registry(self):
+        print("Test case : should successfully run odo init if specified registry is valid")
+
+        with tempfile.TemporaryDirectory() as tmp_workspace:
+            os.chdir(tmp_workspace)
+
+            result = subprocess.run(["odo", "init", "--name", self.COMPONENT, "--devfile", "go",
+                                     "--devfile-registry", "DefaultDevfileRegistry"],
+                                    capture_output=True, text=True, check=True)
+
+            assert check_file_exist("devfile.yaml", tmp_workspace)
+            assert contains(result.stdout,
+                            "Your new component '{}' is ready in the current directory.".format(self.COMPONENT))
+
+            devfile_path = os.path.abspath(os.path.join(tmp_workspace, 'devfile.yaml'))
+            assert query_yaml(devfile_path, "metadata", "name", -1) == self.COMPONENT
 
 
     def test_init_with_starter(self):
-
         print("Test case : should pass and keep the devfile in starter")
 
         with tempfile.TemporaryDirectory() as tmp_workspace:
             os.chdir(tmp_workspace)
 
-            source_devfile_path = os.path.join(os.path.dirname(__file__),
-                                               '../examples/source/devfiles/nodejs/devfile-with-starter-with-devfile.yaml')
-
-            compName = "acomponent"
-            result = subprocess.run(["odo", "init", "--name", compName, "--starter", "nodejs-starter", "--devfile-path", source_devfile_path],
+            # get test devfile path
+            source_devfile_path = get_source_devfile_path("nodejs/devfile-with-starter-with-devfile.yaml")
+            
+            result = subprocess.run(["odo", "init", "--name", self.COMPONENT, "--starter", "nodejs-starter", "--devfile-path", source_devfile_path],
                                     capture_output=True, text=True, check=True)
 
-            assert contains(result.stdout, "Your new component '{}' is ready in the current directory.".format(compName))
-            assert check_file_exist(tmp_workspace, "devfile.yaml")
+            assert contains(result.stdout, "Your new component '{}' is ready in the current directory.".format(self.COMPONENT))
+            assert check_file_exist("devfile.yaml", tmp_workspace)
 
             devfile_path = os.path.abspath(os.path.join(tmp_workspace, 'devfile.yaml'))
-            assert query_yaml(devfile_path, "metadata", "name", -1) == compName
+            assert query_yaml(devfile_path, "metadata", "name", -1) == self.COMPONENT
             assert query_yaml(devfile_path, "metadata", "language", -1) == "nodejs"
 
             list_contents: list[str] = [
@@ -65,71 +143,67 @@ class TestInitCmd:
 
 
     def test_init_with_starter_subdir(self):
-
         print("Test case : should successfully extract the project in the specified subDir path")
 
         with tempfile.TemporaryDirectory() as tmp_workspace:
             os.chdir(tmp_workspace)
 
-            source_devfile_path = os.path.join(os.path.dirname(__file__),
-                                               '../examples/source/devfiles/springboot/devfile-with-subDir.yaml')
-            compName = "acomponent"
-            result = subprocess.run(["odo", "init", "--name", compName, "--starter", "springbootproject", "--devfile-path", source_devfile_path],
+            # get test devfile path
+            source_devfile_path = get_source_devfile_path("springboot/devfile-with-subDir.yaml")
+            
+            result = subprocess.run(["odo", "init", "--name", self.COMPONENT, "--starter", "springbootproject", "--devfile-path", source_devfile_path],
                                     capture_output=True, text=True, check=True)
 
-            assert contains(result.stdout, "Your new component '{}' is ready in the current directory.".format(compName))
+            assert contains(result.stdout, "Your new component '{}' is ready in the current directory.".format(self.COMPONENT))
 
             list_files: list[str] = [
                 "java/com/example/demo/DemoApplication.java",
                 "resources/application.properties"
             ]
-            assert check_files_exist(tmp_workspace, list_files)
+            assert check_files_exist(list_files, tmp_workspace)
 
 
     def test_init_with_starter_and_branch(self):
-
         print("Test case : should successfully run odo init for devfile with starter project from the specified branch")
 
         with tempfile.TemporaryDirectory() as tmp_workspace:
             os.chdir(tmp_workspace)
 
-            source_devfile_path = os.path.join(os.path.dirname(__file__),
-                                               '../examples/source/devfiles/nodejs/devfile-with-branch.yaml')
-            compName = "acomponent"
-            result = subprocess.run(["odo", "init", "--name", compName, "--starter", "nodejs-starter", "--devfile-path", source_devfile_path],
+            # get test devfile path
+            source_devfile_path = get_source_devfile_path("nodejs/devfile-with-branch.yaml")
+            
+            result = subprocess.run(["odo", "init", "--name", self.COMPONENT, "--starter", "nodejs-starter", "--devfile-path", source_devfile_path],
                                     capture_output=True, text=True, check=True)
 
-            assert contains(result.stdout, "Your new component '{}' is ready in the current directory.".format(compName))
+            assert contains(result.stdout, "Your new component '{}' is ready in the current directory.".format(self.COMPONENT))
 
             list_files: list[str] = [
                 "package.json", "package-lock.json", "README.md", "devfile.yaml", "test"
             ]
-            assert check_files_exist(tmp_workspace, list_files)
+            assert check_files_exist(list_files, tmp_workspace)
 
 
     def test_init_with_starter_and_tag(self):
-
         print("Test case : should successfully run odo init for devfile with starter project from the specified tag")
 
         with tempfile.TemporaryDirectory() as tmp_workspace:
             os.chdir(tmp_workspace)
 
-            source_devfile_path = os.path.join(os.path.dirname(__file__),
-                                               '../examples/source/devfiles/nodejs/devfile-with-tag.yaml')
-            compName = "acomponent"
-            result = subprocess.run(["odo", "init", "--name", compName, "--starter", "nodejs-starter", "--devfile-path", source_devfile_path],
+            # get test devfile path
+            source_devfile_path = get_source_devfile_path("nodejs/devfile-with-tag.yaml")
+            
+            result = subprocess.run(["odo", "init", "--name", self.COMPONENT, "--starter", "nodejs-starter", "--devfile-path", source_devfile_path],
                                     capture_output=True, text=True, check=True)
 
-            assert contains(result.stdout, "Your new component '{}' is ready in the current directory.".format(compName))
+            assert contains(result.stdout, "Your new component '{}' is ready in the current directory.".format(self.COMPONENT))
 
             list_files: list[str] = [
                 "package.json", "package-lock.json", "README.md", "devfile.yaml", "app"
             ]
-            assert check_files_exist(tmp_workspace, list_files)
+            assert check_files_exist(list_files, tmp_workspace)
 
 
     def test_init_with_sources(self):
-
         print("Test case : running odo init from a directory with sources")
 
         with tempfile.TemporaryDirectory() as tmp_workspace:
@@ -137,16 +211,15 @@ class TestInitCmd:
             copy_example("nodejs/project", tmp_workspace, self.CONTEXT)
             os.chdir(self.CONTEXT)
 
-            compName = "acomponent"
-
             # should work without --starter flag
-            result = subprocess.run(["odo", "init", "--name", compName, "--devfile", "nodejs"],
+            result = subprocess.run(["odo", "init", "--name", self.COMPONENT, "--devfile", "nodejs"],
                                     capture_output=True, text=True, check=True)
 
-            assert contains(result.stdout, "Your new component '{}' is ready in the current directory.".format(compName))
+            assert contains(result.stdout, "Your new component '{}' is ready in the current directory.".format(self.COMPONENT))
 
             # should not accept --starter flag
-            result = subprocess.run(["odo", "init", "--name", compName, "--devfile", "nodejs", "--starter", "nodejs-starter"],
+            result = subprocess.run(["odo", "init", "--name", self.COMPONENT, "--devfile", "nodejs", "--starter", "nodejs-starter"],
                                     capture_output=True, text=True, check=False)
 
             assert contains(result.stderr, "a devfile already exists in the current directory")
+

--- a/tests/utils/util.py
+++ b/tests/utils/util.py
@@ -109,7 +109,7 @@ def query_yaml(yaml_path: str, param_1, param_2, param_3):
         print(e)
 
 # check if files exist in the context
-def check_files_exist(context, list_files):
+def check_files_exist(list_files, context = '.'):
 
     for expected in list_files:
         path_to_file = os.path.join(context, expected)
@@ -119,8 +119,9 @@ def check_files_exist(context, list_files):
     return True
 
 # check if file exist in the context
-def check_file_exist(context, a_file):
+def check_file_exist(a_file, context = '.'):
     return os.path.exists(os.path.join(context, a_file))
+
 
 # wait until the file exists
 # def wait_for_file(source_dir, filename, timeout = 20):
@@ -164,3 +165,9 @@ def copy_and_create(source_devfile, example_name, workspace_dir, context_dir = '
     copy_example(example_name, workspace_dir, context_dir)
     copy_example_devfile(source_devfile, workspace_dir, context_dir)
     subprocess.run(["odo", "create", "--context", os.path.join(workspace_dir, context_dir)])
+
+# Get source devfile path
+def get_source_devfile_path(source_devfile):
+    return os.path.abspath(os.path.join(os.path.dirname(__file__),
+                            '../examples/source/devfiles',
+                            source_devfile))


### PR DESCRIPTION
Signed-off-by: Joseph Kim <joskim@redhat.com>

### What does this PR do?
Odo v3.0 introduced 'odo init' command. This issue covers adding corresponding integration tests with devfiles.

### What issues does this PR fix or reference?
https://github.com/devfile/api/issues/828

### Is your PR tested? Consider putting some instruction how to test your changes
Locally and by PR test.