### PR TITLE
Use the fixed odo installer for integration test

### DIFF
--- a/.github/workflows/pytest_odo.251.yaml
+++ b/.github/workflows/pytest_odo.251.yaml
@@ -30,31 +30,14 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v2
 
-      - name: Check out the latest odo repository code
-        uses: actions/checkout@v2
-        with:
-          repository: redhat-developer/odo
-          ref: v2.5.1
-          path: odo
-
       - name: Start minikube
         uses: medyagh/setup-minikube@latest
 
-      - name: Setup go
-        uses: actions/setup-go@v3
+      - name: Install ODO
+        uses: redhat-actions/openshift-tools-installer@v1
         with:
-          go-version: '1.16.1'
-      - run: go version
-
-      # Build and installs odo from source code
-      - name: Build and Install ODO
-        run: |
-          cd odo
-          make goget-tools
-          make bin
-          mv ./odo /usr/local/bin/odo
-          cd ..
-          rm -rf odo
+            # Installs the latest release of odo
+            odo: "2.5.1"
 
       # Setup Python
       - name: Install Python, pipenv and Pipfile packages

--- a/tests/odo/test_create_cmd.py
+++ b/tests/odo/test_create_cmd.py
@@ -73,7 +73,7 @@ class TestCreateCmd:
             if os.path.isfile(envfile_path):
                 assert query_yaml(envfile_path, "ComponentSettings", "Project", -1) == component_namespace
             else:
-                raise ValueError("Failed: %s is not created yet." % file_path)
+                raise ValueError("Failed: %s is not created yet." % envfile_path)
 
 
     def test_create_with_context_flag(self):


### PR DESCRIPTION
Signed-off-by: Joseph Kim <joskim@redhat.com>

### What does this PR do?
Replace the workaround with the fix on openshift installer. It used to fail on installing Odo 2.5.1 on macOS for the integration tests.

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/api/issues/841

### Is your PR tested? Consider putting some instructions how to test your changes
Tested local and via PR tests.