### PR TITLE
Update macos level for github action

### DIFF
--- a/.github/workflows/gotest.yaml
+++ b/.github/workflows/gotest.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Run Tests
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-10.15 ]
+        os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     timeout-minutes: 20

--- a/.github/workflows/pytest_odo.251.yaml
+++ b/.github/workflows/pytest_odo.251.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Run tests
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-10.15 ]
+        os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     timeout-minutes: 20

--- a/.github/workflows/pytest_odo.251.yaml
+++ b/.github/workflows/pytest_odo.251.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Run tests
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-12 ]
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     timeout-minutes: 20

--- a/.github/workflows/pytest_odo.300.yaml
+++ b/.github/workflows/pytest_odo.300.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Run tests
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-10.15 ]
+        os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     timeout-minutes: 20

--- a/.github/workflows/pytest_odo.300.yaml
+++ b/.github/workflows/pytest_odo.300.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Run tests
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-12 ]
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     timeout-minutes: 20


### PR DESCRIPTION
Signed-off-by: Joseph Kim <joskim@redhat.com>

### What does this PR do?
Tests failed on macOS 10.15 as Github Actions stop supporting it. 

For more detail:
GitHub Actions : The macOS 10.15 Actions runner image is being deprecated and will be removed by 8/30/22.

https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/

### What issues does this PR fix or reference?
fixes https://github.com/devfile/api/issues/898

### Is your PR tested? Consider putting some instruction how to test your changes
Tested by PR tests.