### PR TITLE
Add .ci-operator.yaml for build_root image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  namespace: openshift
+  name: release
+  tag: golang-1.18

--- a/.github/workflows/pytest_odo.251.yaml.disabled
+++ b/.github/workflows/pytest_odo.251.yaml.disabled
@@ -1,0 +1,59 @@
+#
+#   Copyright 2021-2022 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+name: Devfile integration tests (Odo v2.5.1 release)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    # every day at 9am EST
+    - cron: 0 1 * * *
+
+jobs:
+  test_with_minikube:
+    name: Run tests
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-12 ]
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Start minikube
+        uses: medyagh/setup-minikube@latest
+
+      - name: Install ODO
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+            # Installs the latest release of odo
+            odo: "2.5.1"
+
+      # Setup Python
+      - name: Install Python, pipenv and Pipfile packages
+        uses: palewire/install-python-pipenv-pipfile@v2
+        with:
+          python-version: "3.9.10"
+
+      - name: Run test with pipenv and pytest
+        run: |
+          odo version
+          pipenv run pytest tests/odo -v

--- a/.github/workflows/pytest_odo.300.yaml.disabled
+++ b/.github/workflows/pytest_odo.300.yaml.disabled
@@ -1,0 +1,77 @@
+#
+#   Copyright 2021-2022 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+name: Devfile integration tests (latest Odo build)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    # every day at 9am EST
+    - cron: 0 1 * * *
+
+jobs:
+  test_with_minikube:
+    name: Run tests
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-12 ]
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Check out the latest odo repository code
+        uses: actions/checkout@v3
+        with:
+          repository: redhat-developer/odo
+          ref: main
+          path: odo
+
+      - name: Start minikube
+        uses: medyagh/setup-minikube@latest
+
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.17.3'
+      - run: go version
+
+      # Build and installs odo from source code
+      - name: Build and Install ODO
+        run: |
+          cd odo
+          make goget-tools
+          make bin
+          mv ./odo /usr/local/bin/odo
+          cd ..
+          rm -rf odo
+
+      # Setup Python
+      - name: Install Python, pipenv and Pipfile packages
+        uses: palewire/install-python-pipenv-pipfile@v2
+        with:
+          python-version: "3.9.10"
+
+      - name: Run test with pipenv and pytest
+        run: |
+          odo version
+          pipenv run pytest tests/odo_300 -v
+


### PR DESCRIPTION
Signed-off-by: Joseph Kim <joskim@redhat.com>

### What does this PR do?
In order to support GO 1.18, add _.ci-operator.yaml_  to configure to build root image within the repository.

### What issues does this PR fix or reference?


### Is your PR tested? Consider putting some instruction how to test your changes
