### PR TITLE
Update Go version to 1.19 for Odo integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ NOTE: each run of the test removes the existing contents of the ```./tmp``` dire
 [ODO integration tests](https://github.com/openshift/odo/blob/main/docs/dev/test-architecture.adoc#integration-and-e2e-tests) 
 
 ### Prerequisites
-- Go 1.16 and Ginkgo latest version
+- Go 1.19 and Ginkgo latest version
 - git
 - [OpenShift Cluster](https://github.com/openshift/odo/blob/main/docs/dev/test-architecture.adoc#integration-and-e2e-tests).  e.g. crc environment for 4.* local cluster 
 - [Optional] [xunit-viewer](https://www.npmjs.com/package/xunit-viewer)
@@ -99,7 +99,7 @@ Tests in this repository are based on [ODC integration tests](https://github.com
 
 ### Prerequisites
 1. [node.js](https://nodejs.org/) >= 14 & [yarn](https://yarnpkg.com/en/docs/install) >= 1.20
-2. [go](https://golang.org/) >= 1.16+
+2. [go](https://golang.org/) >= 1.19+
 3. [oc](https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.4/) or [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and an OpenShift or Kubernetes cluster. In this document, [CRC](https://cloud.redhat.com/openshift/create/local) is used.
 4. [jq](https://stedolan.github.io/jq/download/) (for `contrib/environment.sh`)
 5. Google Chrome/Chromium or Firefox for integration tests

--- a/openshift-ci/build-root/Dockerfile
+++ b/openshift-ci/build-root/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.18
+FROM registry.ci.openshift.org/openshift/release:golang-1.19
 
 RUN yum -y install make wget gcc git httpd-tools
 


### PR DESCRIPTION
### What does this PR do?
Fix integration test failure by bumping up the go version to 1.19.

+ go mod tidy
go: go.mod file indicates go 1.19, but maximum version supported by tidy is 1.18

### What issues does this PR fix or reference?


### Is your PR tested? Consider putting some instruction how to test your changes
