### PR TITLE
Fix setting up Go environment in workflow

### DIFF
--- a/.github/workflows/gotest.yaml
+++ b/.github/workflows/gotest.yaml
@@ -19,14 +19,14 @@ jobs:
     timeout-minutes: 20
 
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      
       - name: Setup Go environment
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version-file: 'go.mod'
         id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Check go mod status
         run: |


### PR DESCRIPTION
### What does this PR do?

Setting the Go version by the `go.mod` file was implemented in #105, however this requires that the source is checked out first _before_ setting up the Go environment.

### What issues does this PR fix or reference?

N/A

### Is your PR tested? Consider putting some instruction how to test your changes
